### PR TITLE
Meilisearch: Use --experimental-dumpless-upgrade

### DIFF
--- a/conf/meilisearch.service
+++ b/conf/meilisearch.service
@@ -7,7 +7,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__INSTALL_DIR__/meilisearch
-ExecStart=__INSTALL_DIR__/meilisearch/meilisearch --config-file-path __INSTALL_DIR__/meilisearch/config.toml
+ExecStart=__INSTALL_DIR__/meilisearch/meilisearch --config-file-path __INSTALL_DIR__/meilisearch/config.toml --experimental-dumpless-upgrade
 
 # Sandboxing options to harden security
 # Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html


### PR DESCRIPTION
## Problem

- Upgrade of peertube-search-index makes the service fail

## Solution

- use the `--experimental-dumpless-upgrade` option

This options is experimental but supports for upgrade of database seamlessly. Also [it is already used in meilisearch_ynh](https://github.com/YunoHost-Apps/meilisearch_ynh/blob/07fff830b53ceb6fd00c92b7de9f2b8e89ed802b/conf/systemd.service#L10).

See: https://www.meilisearch.com/docs/learn/update_and_migration/updating#dumpless-upgrade

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
